### PR TITLE
Draft of adding pairwise f3

### DIFF
--- a/msprime/trees.py
+++ b/msprime/trees.py
@@ -2243,7 +2243,8 @@ class TreeSequence(object):
     @staticmethod
     def _f3(x1, x2, xX, n1, n2, nX):
         # use relation to f2. see Table 1 of Peters 2016 10.1534/genetics.115.183913
-        return 1/2 * (TreeSequence._f2(x1, xX, n1, nX) + 
+        # the order of arguments there is f3(pX; p1, p2) and differs here
+        return 1/2 * (TreeSequence._f2(x1, xX, n1, nX) +
                       TreeSequence._f2(x2, xX, n2, xX) -
                       TreeSequence._f2(x1, x2, n1, n2))
 
@@ -2266,7 +2267,7 @@ class TreeSequence(object):
         n = [len(x) for x in leaf_sets]
 
         def f(x):
-            return [TreeSequence._f3(x[i], x[i], x[j], x[i], x[i], x[j])
+            return [TreeSequence._f3(x[i], x[i], x[j], n[i], n[i], n[j])
                     for i in range(nleaves) for j in range(i, nleaves)]
 
         return self.branch_stats_vector(leaf_sets, weight_fun=f, windows=windows)

--- a/tests/test_branch_stats.py
+++ b/tests/test_branch_stats.py
@@ -305,7 +305,7 @@ class BranchStatsTestCase(unittest.TestCase):
         self.assertListEqual([len(x) for x in ts_values], [6, 6])
         assert(len(A[2]) == 1)
         self.assertListEqual([x[5] for x in ts_values], [0.0, 0.0])
-        here_values = [[branch_length_Y(ts, A[i], A[j], begin=windows[k],
+        here_values = [[branch_length_Y(ts, A[j], A[i], A[i], begin=windows[k],
                                                 end=windows[k+1])
                         for i in range(len(A)) for j in range(i, len(A))]
                        for k in range(len(windows)-1)]


### PR DESCRIPTION
This adds a naive attempt to calculate pairwise f3 between pairs of populations. The goal is to add (for f3 and or Y-stat) something that operates pairwise on all pairs from a set of populations using the same machinery of `mean_pairwise_tmrca`. 

The current test is just comparing to previous setup for Y-stat; so I expect it to fail. However there is some issue with the concept or implementation as it causes a divide by zero error in attempting to calculate this stat.

Currently this just attempts to calculate, for two population pairs $p_i$ and $p_j$, the stat $f_3(p_j; p_i, p_i)$ (using the argument order of Peters; see screenshot below). It's also implemented with Peter's statement in terms of $f_2$

![image](https://user-images.githubusercontent.com/510776/27722208-f85d7646-5d1a-11e7-96f1-3645e5cfadb3.png)

